### PR TITLE
Run type checker and linter during build.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,8 @@ RUN uv sync
 # Copy over remaining code, tests, and configurations
 COPY . .
 
-# Perform type checking at build time
+# Perform type checking and linting at build time
 RUN uv run ty check
+RUN uv run ruff check
 
 ENTRYPOINT ["/bin/bash", "-c", "uv run -m unittest"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,4 +8,7 @@ RUN uv sync
 # Copy over remaining code, tests, and configurations
 COPY . .
 
+# Perform type checking at build time
+RUN uv run ty check
+
 ENTRYPOINT ["/bin/bash", "-c", "uv run -m unittest"]

--- a/README.md
+++ b/README.md
@@ -33,16 +33,17 @@ cd p79-sample
 uv sync
 ```
 
-The `run.sh` script builds and runs the Docker image. It will execute the typec hecker during the build process and then run the unit tests in a container.
+The `run.sh` script builds and runs the Docker image. It executes the type checker and linter during the build process and then runs the unit tests in a container.
 
 ```bash
 ./run.sh
 ```
 
-You can run the type checker and the unit tests locally as well:
+You can run the type checker, linter, and the unit tests locally as well:
 
 ```bash
 uv run ty check
+uv run ruff check
 uv run -m unittest
 ```
 

--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ You will need to install the following:
 - [uv](https://docs.astral.sh/uv/getting-started/installation/)
 - [Docker](https://docs.docker.com/get-docker/)
 
-### Docker macOS Issue
-If you experience issues with macOS identifying Docker Desktop as Malware, these resources helped me to resolve this:
+### Docker macOs Issue (2025)
+If you experience issues with MacOS identifying Docker Desktop as Malware, these resources helped me to resolve this:
 - https://docs.docker.com/desktop/cert-revoke-solution/
 - https://www.docker.com/blog/incident-update-docker-desktop-for-mac/
 - https://github.com/docker/for-mac/issues/7527
@@ -24,25 +24,26 @@ If you experience issues with macOS identifying Docker Desktop as Malware, these
 
 ## Development
 
-For local development, you will want to clone the repository, install the dependencies, and then build and run the Docker image.
+For local development, clone the repository and let `uv` create a virtual with the required dependencies.
+
 
 ```bash
 git clone git@github.com:lambdapioneer/p79-sample.git
 cd p79-sample
 uv sync
+```
+
+The `run.sh` script builds and runs the Docker image. It will execute the typec hecker during the build process and then run the unit tests in a container.
+
+```bash
 ./run.sh
 ```
 
-You can run all tests with:
+You can run the type checker and the unit tests locally as well:
 
 ```bash
+uv run ty check
 uv run -m unittest
-```
-
-You can check your types with:
-
-```bash
-uvx ty check
 ```
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,7 @@ readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
     "pynacl==1.5.0",
+    "ruff>=0.14.13",
 ]
 
 [dependency-groups]

--- a/run.sh
+++ b/run.sh
@@ -5,7 +5,14 @@ set -e;
 cd "$(dirname "$0")"
 
 # Build the Docker image
+echo ""
+echo "--- BUILDING ---"
+echo ""
 docker build -t p79-runner .
 
+
 # Run the container
+echo ""
+echo "--- RUNNING ---"
+echo ""
 docker run --rm p79-runner

--- a/uv.lock
+++ b/uv.lock
@@ -41,6 +41,7 @@ version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
     { name = "pynacl" },
+    { name = "ruff" },
 ]
 
 [package.dev-dependencies]
@@ -49,7 +50,10 @@ dev = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "pynacl", specifier = "==1.5.0" }]
+requires-dist = [
+    { name = "pynacl", specifier = "==1.5.0" },
+    { name = "ruff", specifier = ">=0.14.13" },
+]
 
 [package.metadata.requires-dev]
 dev = [{ name = "ty", specifier = ">=0.0.8" }]
@@ -81,6 +85,32 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/fd/1a/cc308a884bd299b651f1633acb978e8596c71c33ca85e9dc9fa33a5399b9/PyNaCl-1.5.0-cp36-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:61f642bf2378713e2c2e1de73444a3778e5f0a38be6fee0fe532fe30060282ff", size = 1117912, upload-time = "2022-01-07T22:05:58.665Z" },
     { url = "https://files.pythonhosted.org/packages/25/2d/b7df6ddb0c2a33afdb358f8af6ea3b8c4d1196ca45497dd37a56f0c122be/PyNaCl-1.5.0-cp36-abi3-win32.whl", hash = "sha256:e46dae94e34b085175f8abb3b0aaa7da40767865ac82c928eeb9e57e1ea8a543", size = 204624, upload-time = "2022-01-07T22:06:00.085Z" },
     { url = "https://files.pythonhosted.org/packages/5e/22/d3db169895faaf3e2eda892f005f433a62db2decbcfbc2f61e6517adfa87/PyNaCl-1.5.0-cp36-abi3-win_amd64.whl", hash = "sha256:20f42270d27e1b6a29f54032090b972d97f0a1b0948cc52392041ef7831fee93", size = 212141, upload-time = "2022-01-07T22:06:01.861Z" },
+]
+
+[[package]]
+name = "ruff"
+version = "0.14.13"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/50/0a/1914efb7903174b381ee2ffeebb4253e729de57f114e63595114c8ca451f/ruff-0.14.13.tar.gz", hash = "sha256:83cd6c0763190784b99650a20fec7633c59f6ebe41c5cc9d45ee42749563ad47", size = 6059504, upload-time = "2026-01-15T20:15:16.918Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c3/ae/0deefbc65ca74b0ab1fd3917f94dc3b398233346a74b8bbb0a916a1a6bf6/ruff-0.14.13-py3-none-linux_armv6l.whl", hash = "sha256:76f62c62cd37c276cb03a275b198c7c15bd1d60c989f944db08a8c1c2dbec18b", size = 13062418, upload-time = "2026-01-15T20:14:50.779Z" },
+    { url = "https://files.pythonhosted.org/packages/47/df/5916604faa530a97a3c154c62a81cb6b735c0cb05d1e26d5ad0f0c8ac48a/ruff-0.14.13-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:914a8023ece0528d5cc33f5a684f5f38199bbb566a04815c2c211d8f40b5d0ed", size = 13442344, upload-time = "2026-01-15T20:15:07.94Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/f3/e0e694dd69163c3a1671e102aa574a50357536f18a33375050334d5cd517/ruff-0.14.13-py3-none-macosx_11_0_arm64.whl", hash = "sha256:d24899478c35ebfa730597a4a775d430ad0d5631b8647a3ab368c29b7e7bd063", size = 12354720, upload-time = "2026-01-15T20:15:09.854Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/e8/67f5fcbbaee25e8fc3b56cc33e9892eca7ffe09f773c8e5907757a7e3bdb/ruff-0.14.13-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9aaf3870f14d925bbaf18b8a2347ee0ae7d95a2e490e4d4aea6813ed15ebc80e", size = 12774493, upload-time = "2026-01-15T20:15:20.908Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/ce/d2e9cb510870b52a9565d885c0d7668cc050e30fa2c8ac3fb1fda15c083d/ruff-0.14.13-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:ac5b7f63dd3b27cc811850f5ffd8fff845b00ad70e60b043aabf8d6ecc304e09", size = 12815174, upload-time = "2026-01-15T20:15:05.74Z" },
+    { url = "https://files.pythonhosted.org/packages/88/00/c38e5da58beebcf4fa32d0ddd993b63dfacefd02ab7922614231330845bf/ruff-0.14.13-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:78d2b1097750d90ba82ce4ba676e85230a0ed694178ca5e61aa9b459970b3eb9", size = 13680909, upload-time = "2026-01-15T20:15:14.537Z" },
+    { url = "https://files.pythonhosted.org/packages/61/61/cd37c9dd5bd0a3099ba79b2a5899ad417d8f3b04038810b0501a80814fd7/ruff-0.14.13-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:7d0bf87705acbbcb8d4c24b2d77fbb73d40210a95c3903b443cd9e30824a5032", size = 15144215, upload-time = "2026-01-15T20:15:22.886Z" },
+    { url = "https://files.pythonhosted.org/packages/56/8a/85502d7edbf98c2df7b8876f316c0157359165e16cdf98507c65c8d07d3d/ruff-0.14.13-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a3eb5da8e2c9e9f13431032fdcbe7681de9ceda5835efee3269417c13f1fed5c", size = 14706067, upload-time = "2026-01-15T20:14:48.271Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/2f/de0df127feb2ee8c1e54354dc1179b4a23798f0866019528c938ba439aca/ruff-0.14.13-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:642442b42957093811cd8d2140dfadd19c7417030a7a68cf8d51fcdd5f217427", size = 14133916, upload-time = "2026-01-15T20:14:57.357Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/77/9b99686bb9fe07a757c82f6f95e555c7a47801a9305576a9c67e0a31d280/ruff-0.14.13-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4acdf009f32b46f6e8864af19cbf6841eaaed8638e65c8dac845aea0d703c841", size = 13859207, upload-time = "2026-01-15T20:14:55.111Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/46/2bdcb34a87a179a4d23022d818c1c236cb40e477faf0d7c9afb6813e5876/ruff-0.14.13-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:591a7f68860ea4e003917d19b5c4f5ac39ff558f162dc753a2c5de897fd5502c", size = 14043686, upload-time = "2026-01-15T20:14:52.841Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/a9/5c6a4f56a0512c691cf143371bcf60505ed0f0860f24a85da8bd123b2bf1/ruff-0.14.13-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:774c77e841cc6e046fc3e91623ce0903d1cd07e3a36b1a9fe79b81dab3de506b", size = 12663837, upload-time = "2026-01-15T20:15:18.921Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/bb/b920016ece7651fa7fcd335d9d199306665486694d4361547ccb19394c44/ruff-0.14.13-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:61f4e40077a1248436772bb6512db5fc4457fe4c49e7a94ea7c5088655dd21ae", size = 12805867, upload-time = "2026-01-15T20:14:59.272Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/b3/0bd909851e5696cd21e32a8fc25727e5f58f1934b3596975503e6e85415c/ruff-0.14.13-py3-none-musllinux_1_2_i686.whl", hash = "sha256:6d02f1428357fae9e98ac7aa94b7e966fd24151088510d32cf6f902d6c09235e", size = 13208528, upload-time = "2026-01-15T20:15:03.732Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/3b/e2d94cb613f6bbd5155a75cbe072813756363eba46a3f2177a1fcd0cd670/ruff-0.14.13-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:e399341472ce15237be0c0ae5fbceca4b04cd9bebab1a2b2c979e015455d8f0c", size = 13929242, upload-time = "2026-01-15T20:15:11.918Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/c5/abd840d4132fd51a12f594934af5eba1d5d27298a6f5b5d6c3be45301caf/ruff-0.14.13-py3-none-win32.whl", hash = "sha256:ef720f529aec113968b45dfdb838ac8934e519711da53a0456038a0efecbd680", size = 12919024, upload-time = "2026-01-15T20:14:43.647Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/55/6384b0b8ce731b6e2ade2b5449bf07c0e4c31e8a2e68ea65b3bafadcecc5/ruff-0.14.13-py3-none-win_amd64.whl", hash = "sha256:6070bd026e409734b9257e03e3ef18c6e1a216f0435c6751d7a8ec69cb59abef", size = 14097887, upload-time = "2026-01-15T20:15:01.48Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/e1/7348090988095e4e39560cfc2f7555b1b2a7357deba19167b600fdf5215d/ruff-0.14.13-py3-none-win_arm64.whl", hash = "sha256:7ab819e14f1ad9fe39f246cfcc435880ef7a9390d81a2b6ac7e01039083dd247", size = 13080224, upload-time = "2026-01-15T20:14:45.853Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
As suggested in the linked issue, we'll want to run the type checker during the build process initiated by `run.sh` as well. It's a good idea to also add a linter. I've done some minor tweaks to clarify the `README.md`

Closes #3 

```
daniel@x1:~/dev/uni/p79-sample$ ./run.sh 

--- BUILDING ---

Emulate Docker CLI using podman. Create /etc/containers/nodocker to quiet msg.
STEP 1/8: FROM ghcr.io/astral-sh/uv:python3.12-trixie-slim
STEP 2/8: WORKDIR /app
--> Using cache cd8cc7a5dc9b097bd3e877eb0fa14772021c7bbf0d008933193dc1b83026f0ad
--> cd8cc7a5dc9b
STEP 3/8: COPY pyproject.toml .
--> Using cache a329ad141299b5e68b5ab38563372388d6417a4d7e85b23a315375dc51bacc79
--> a329ad141299
STEP 4/8: RUN uv sync
--> Using cache edf31665aa8a4a019092158995caf6e975c4b8e3f0bdbedbb5acf45ab3a636a7
--> edf31665aa8a
STEP 5/8: COPY . .
--> 273aac954d72
STEP 6/8: RUN uv run ty check
Downloading ty (9.7MiB)
 Downloaded ty
Uninstalled 3 packages in 2ms
Installed 3 packages in 3ms
All checks passed!
--> da252f8e1900
STEP 7/8: RUN uv run ruff check
All checks passed!
--> ad3d5ed3c161
STEP 8/8: ENTRYPOINT ["/bin/bash", "-c", "uv run -m unittest"]
COMMIT p79-runner
--> 968308b77f04
Successfully tagged localhost/p79-runner:latest
968308b77f048caffaad39e7aa0417f0957097a37a20e1d1a4368ede817f35e3

--- RUNNING ---

Emulate Docker CLI using podman. Create /etc/containers/nodocker to quiet msg.
EFF.
======================================================================
ERROR: test_blake2b_default_length (tests.test_diggest.TestDigest.test_blake2b_default_length)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/app/tests/test_diggest.py", line 14, in test_blake2b_default_length
    result = digest.digest(data)
             ^^^^^^^^^^^^^^^^^^^
  File "/app/hash/digest.py", line 60, in digest
    raise NotImplementedError("BLAKE2 is not implemented")
NotImplementedError: BLAKE2 is not implemented

======================================================================
FAIL: test_init_checks_for_too_large_output_length (tests.test_diggest.TestDigest.test_init_checks_for_too_large_output_length)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/app/tests/test_diggest.py", line 24, in test_init_checks_for_too_large_output_length
    with self.assertRaises(AssertionError):
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AssertionError: AssertionError not raised

======================================================================
FAIL: test_sha256_custom_length (tests.test_diggest.TestDigest.test_sha256_custom_length)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/app/tests/test_diggest.py", line 43, in test_sha256_custom_length
    self.assertEqual(len(result), 16)
AssertionError: 32 != 16

----------------------------------------------------------------------
Ran 4 tests in 0.000s

FAILED (failures=2, errors=1)
```